### PR TITLE
fix: 修改! -z 为!-z

### DIFF
--- a/mariadb/bin/install
+++ b/mariadb/bin/install
@@ -1,25 +1,26 @@
 #!/bin/sh
 
+set -e
 echo "Installing..."
 /usr/bin/mysql_install_db --user=mysql --datadir=/var/lib/mysql > /dev/null 2>&1
 
 mkdir -p /run/mysqld && chown mysql /run/mysqld
 /usr/bin/mysqld --user=mysql --skip-networking > /dev/null 2>&1 &
 
-if [ ! -z $MYSQL_USER ]
+if [ !-z $MYSQL_USER ]
 then
     MYSQL_USER="genee"
 fi
 
-if [ ! -z $MYSQL_PASS ]
+if [ !-z $MYSQL_PASS ]
 then
     MYSQL_PASS="83719730"
 fi
 
-sleep 3s && \
-    mysql -uroot -e "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASS'" && \
-    mysql -uroot -e "GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%' WITH GRANT OPTION" && \
-    mysql -uroot -e "FLUSH PRIVILEGES"
+sleep 3s
+mysql -uroot -e "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASS';
+	GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%' WITH GRANT OPTION;
+	FLUSH PRIVILEGES"
 
 echo "Done!"
 


### PR DESCRIPTION
修改! -z为!-z
增加set -e

通过 ”&&"执行命令时，set -e 无法捕捉到error