### PR TITLE
修正sftp

### DIFF
--- a/sftp/Dockerfile
+++ b/sftp/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:latest
 
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories
+
 RUN apk add --upgrade --no-cache bash openssh
 
 ENV FTP_USER=sftp \

--- a/sftp/docker-compose.yml
+++ b/sftp/docker-compose.yml
@@ -10,4 +10,4 @@ sftp:
   - "FTP_USER=sftp"
   - "FTP_PASS=sftp"
   volumes:
-  - "<YOUR_FTP_DIRECTORY>:/var/lib/ftp"
+  - "<YOUR_FTP_DIRECTORY>:/var/lib/jail/ftp"

--- a/sftp/start
+++ b/sftp/start
@@ -4,10 +4,10 @@ set -e
 
 FTP_DIR=/var/lib/ftp
 FTP_JAIL=/var/lib/jail
-FTP_HOME="${FTP_JAIL}/${FTP_USER}"
+FTP_HOME=${FTP_JAIL}/ftp
 
 if [ ! -d ${FTP_HOME} ]; then
-    mkdir -p ${FTP_HOME}
+    mkdir -p ${FTP_JAIL}
 fi
 
 chown root:root ${FTP_JAIL}
@@ -17,17 +17,16 @@ if [ -d ${FTP_DIR} ]; then
     FTP_GID=$(stat -c %g ${FTP_DIR})
 fi
 
-if ${FTP_UID} == '0'; then
+if [ ${FTP_UID} == '0' ]; then
     FTP_UID=1000
     chown ${FTP_UID} ${FTP_DIR}
 fi
 
-if ${FTP_GID} == '0'; then
+if [ ${FTP_GID} == '0' ]; then
     FTP_GID=1000
     chgrp ${FTP_GID} ${FTP_DIR}
 fi
 
-mount --bind ${FTP_DIR} ${FTP_HOME}
 
 if ! getent group ${FTP_GROUP} > /dev/null 2>&1; then
 	addgroup -g ${FTP_GID} ${FTP_GROUP}


### PR DESCRIPTION
mount --bind 在docker内部执行会报错 权限不足，无法挂载，所以删除
直接将FTP_USER的固化为/var/lib/jail/ftp
直接将代码目录挂载到/var/lib/jail/ftp

start的20行和25的if判断语句少了中括号，补上